### PR TITLE
allow batch embedding on every .png file located at the `EMBED` subdirectory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ src/boot.s: etc/boot.lua
 	echo "Embedding boot script..."
 	$(BIN2S) $< $@ bootString
 
+# Images
+EMBED/%.s: EMBED/%.png
+	$(BIN2S) $< $@ $(shell basename $< .png)
+	echo "Embedding $< Image..."
 #------------------------------------------------------------------#
 
 
@@ -228,8 +232,9 @@ clean:
 	$(MAKE) -C modules/ds34usb clean
 	$(MAKE) -C modules/ds34bt clean
 	
-	echo "Cleaning embedded boot script..."
-	rm -f src/boot.s
+	
+	echo "Cleaning embedded Resources..."
+	rm -f $(EMBEDDED_RSC)
 
 rebuild: clean all
 


### PR DESCRIPTION
For organizative purposes.

I recommend that the .o declaration should be added into `$(EMBEDDED_RSC)`

Useless at the moment nut if embedded images become a feature in the future this will be helpful

Saving you the time of writing recipe for every image