### PR TITLE
make git ownership workaround more flexible

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Workaround permission issue
       run: |
-        git config --global --add safe.directory /__w/Enceladus/Enceladus
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - uses: actions/checkout@v2
     - run: |


### PR DESCRIPTION
this allows people to rename it's forked repository without making an unnecesary commit updating the CI