### PR TITLE
simplify makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DEBUG = 0
 #----------------------- Set IP for PS2Client ---------------------#
 PS2LINK_IP = 192.168.1.10
 #------------------------------------------------------------------#
-
+BINDIR = bin/
 EE_BIN = enceladus.elf
 EE_BIN_PKD = enceladus_pkd.elf
 
@@ -71,14 +71,14 @@ LUA_LIBS =	luaplayer.o luasound.o luacontrols.o \
 			luatimer.o luaScreen.o luagraphics.o \
 			luasystem.o luaRender.o
 
-IOP_MODULES = iomanx.o filexio.o \
+IOP_MODULES = iomanX.o fileXio.o \
 			  sio2man.o mcman.o mcserv.o padman.o libsd.o \
 			  usbd.o audsrv.o bdm.o bdmfs_fatfs.o \
 			  usbmass_bd.o cdfs.o ds34bt.o ds34usb.o
 
 EMBEDDED_RSC = boot.o
 
-EE_OBJS = $(IOP_MODULES) $(EMBEDDED_RSC) $(APP_CORE) $(LUA_LIBS)
+EE_OBJS = $(APP_CORE) $(LUA_LIBS) $(IOP_MODULES) $(EMBEDDED_RSC)
 
 EE_OBJS_DIR = obj/
 EE_SRC_DIR = src/
@@ -89,78 +89,28 @@ EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%) # remap all EE_OBJ to obj subdir
 all: $(EXT_LIBS) $(EE_BIN)
 	@echo "$$HEADER"
 
-	echo "Building $(EE_BIN)..."
-	$(EE_STRIP) $(EE_BIN)
+	$(EE_STRIP) $(BINDIR)$(EE_BIN)
 
-	echo "Compressing $(EE_BIN_PKD)...\n"
-	ps2-packer $(EE_BIN) $(EE_BIN_PKD) > /dev/null
+	ps2-packer $(BINDIR)$(EE_BIN) $(BINDIR)$(EE_BIN_PKD) > /dev/null
 	
-	mv $(EE_BIN) bin/
-	mv $(EE_BIN_PKD) bin/
 #--------------------- Embedded ressources ------------------------#
 
 $(EE_ASM_DIR)boot.s: etc/boot.lua | $(EE_ASM_DIR)
-	echo "Embedding boot script..."
 	$(BIN2S) $< $@ bootString
 
 # Images
 EMBED/%.s: EMBED/%.png
 	$(BIN2S) $< $@ $(shell basename $< .png)
-	echo "Embedding $< Image..."
 #------------------------------------------------------------------#
 
 
 #-------------------- Embedded IOP Modules ------------------------#
-$(EE_ASM_DIR)iomanx.s: $(PS2SDK)/iop/irx/iomanX.irx | $(EE_ASM_DIR)
-	echo "Embedding iomanX Driver..."
-	$(BIN2S) $< $@ iomanX_irx
-
-$(EE_ASM_DIR)filexio.s: $(PS2SDK)/iop/irx/fileXio.irx | $(EE_ASM_DIR)
-	echo "Embedding fileXio Driver..."
-	$(BIN2S) $< $@ fileXio_irx
-
-$(EE_ASM_DIR)sio2man.s: $(PS2SDK)/iop/irx/sio2man.irx | $(EE_ASM_DIR)
-	echo "Embedding SIO2MAN Driver..."
-	$(BIN2S) $< $@ sio2man_irx
-	
-$(EE_ASM_DIR)mcman.s: $(PS2SDK)/iop/irx/mcman.irx | $(EE_ASM_DIR)
-	echo "Embedding MCMAN Driver..."
-	$(BIN2S) $< $@ mcman_irx
-
-$(EE_ASM_DIR)mcserv.s: $(PS2SDK)/iop/irx/mcserv.irx | $(EE_ASM_DIR)
-	echo "Embedding MCSERV Driver..."
-	$(BIN2S) $< $@ mcserv_irx
-
-$(EE_ASM_DIR)padman.s: $(PS2SDK)/iop/irx/padman.irx | $(EE_ASM_DIR)
-	echo "Embedding PADMAN Driver..."
-	$(BIN2S) $< $@ padman_irx
-	
-$(EE_ASM_DIR)libsd.s: $(PS2SDK)/iop/irx/libsd.irx | $(EE_ASM_DIR)
-	echo "Embedding LIBSD Driver..."
-	$(BIN2S) $< $@ libsd_irx
-
-$(EE_ASM_DIR)usbd.s: $(PS2SDK)/iop/irx/usbd.irx | $(EE_ASM_DIR)
-	echo "Embedding USB Driver..."
-	$(BIN2S) $< $@ usbd_irx
-
-$(EE_ASM_DIR)audsrv.s: $(PS2SDK)/iop/irx/audsrv.irx | $(EE_ASM_DIR)
-	echo "Embedding AUDSRV Driver..."
-	$(BIN2S) $< $@ audsrv_irx
-
-$(EE_ASM_DIR)bdm.s: $(PS2SDK)/iop/irx/bdm.irx | $(EE_ASM_DIR)
-	echo "Embedding Block Device Manager(BDM)..."
-	$(BIN2S) $< $@ bdm_irx
-
-$(EE_ASM_DIR)bdmfs_fatfs.s: $(PS2SDK)/iop/irx/bdmfs_fatfs.irx | $(EE_ASM_DIR)
-	echo "Embedding BDM FATFS Driver..."
-	$(BIN2S) $< $@ bdmfs_fatfs_irx
-
-$(EE_ASM_DIR)usbmass_bd.s: $(PS2SDK)/iop/irx/usbmass_bd.irx | $(EE_ASM_DIR)
-	echo "Embedding BD USB Mass Driver..."
-	$(BIN2S) $< $@ usbmass_bd_irx
-
-$(EE_ASM_DIR)cdfs.s: $(PS2SDK)/iop/irx/cdfs.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ cdfs_irx
+vpath %.irx embed/iop/
+vpath %.irx $(PS2SDK)/iop/irx/
+IRXTAG = $(notdir $(addsuffix _irx, $(basename $<)))
+$(EE_ASM_DIR)%.s: %.irx
+	$(DIR_GUARD)
+	$(BIN2S) $< $@ $(IRXTAG)
 
 modules/ds34bt/ee/libds34bt.a: modules/ds34bt/ee
 	$(MAKE) -C $<
@@ -168,18 +118,11 @@ modules/ds34bt/ee/libds34bt.a: modules/ds34bt/ee
 modules/ds34bt/iop/ds34bt.irx: modules/ds34bt/iop
 	$(MAKE) -C $<
 
-$(EE_ASM_DIR)ds34bt.s: modules/ds34bt/iop/ds34bt.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ds34bt_irx
-
 modules/ds34usb/ee/libds34usb.a: modules/ds34usb/ee
 	$(MAKE) -C $<
 
 modules/ds34usb/iop/ds34usb.irx: modules/ds34usb/iop
 	$(MAKE) -C $<
-
-$(EE_ASM_DIR)ds34usb.s: modules/ds34usb/iop/ds34usb.irx | $(EE_ASM_DIR)
-	$(BIN2S) $< $@ ds34usb_irx
-	
 #------------------------------------------------------------------#
 
 $(EE_OBJS_DIR):
@@ -192,23 +135,12 @@ debug: $(EE_BIN)
 	echo "Building $(EE_BIN) with debug symbols..."
 
 clean:
-
-	@echo "\nCleaning $(EE_BIN)..."
-	rm -f bin/$(EE_BIN)
-
-	@echo "\nCleaning $(EE_BIN_PKD)..."
-	rm -f bin/$(EE_BIN_PKD)
-
-	@echo "Cleaning obj dir"
 	@rm -rf $(EE_OBJS_DIR)
-	@echo "Cleaning asm dir"
 	@rm -rf $(EE_ASM_DIR)
-	
 	$(MAKE) -C modules/ds34usb clean
 	$(MAKE) -C modules/ds34bt clean
-	
-	
-	echo "Cleaning embedded Resources..."
+	rm -f $(BINDIR)$(EE_BIN)
+	rm -f $(BINDIR)$(EE_BIN_PKD)
 	rm -f $(EMBEDDED_RSC)
 
 rebuild: clean all

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ EMBED/%.s: EMBED/%.png
 
 #-------------------- Embedded IOP Modules ------------------------#
 vpath %.irx embed/iop/
+vpath %.irx modules/ds34bt/iop/
+vpath %.irx modules/ds34usb/iop/
 vpath %.irx $(PS2SDK)/iop/irx/
 IRXTAG = $(notdir $(addsuffix _irx, $(basename $<)))
 $(EE_ASM_DIR)%.s: %.irx


### PR DESCRIPTION
- no more per-irx recipes
- faster dispatching of final binaries (write them to bin folder directly, no copying in the middle)