### PR TITLE
enhance IRX loading

### DIFF
--- a/src/luasystem.cpp
+++ b/src/luasystem.cpp
@@ -702,10 +702,12 @@ static int lua_sifloadmodule(lua_State *L){
 		args = luaL_checkstring(L, 3);
 	}
 	
-
-	int result = SifLoadModule(path, arg_len, args);
+	int result;
+	int irx_id = SifLoadStartModule(path, arg_len, args, &result);
+	printf("%s: '%s' with %d args.\tIRX ID=%d, IRX ret=%d\n", __FUNCTION__, path, arg_len, irx_id, result);
 	lua_pushinteger(L, result);
-	return 1;
+	lua_pushinteger(L, irx_id);
+	return 2;
 }
 
 


### PR DESCRIPTION
this change lets the lua side know the real IRX return value, in addition to the IRX ID (wich was already there)

This is very important, because there can be cases where a module starts correctly (then IRX ID is nonzero), but then an issue arises, and the module willingly requests to be unloaded (by returning `MODULE_NO_RESIDENT_END`)

Also, note some modules (such as IOP FreeRam and ADDDRV, will always return `MODULE_NO_RESIDENT_END`, because their jobs do not require staying active on IOP